### PR TITLE
Fix overlay popping up for half a second at startup (#77)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ product.overrides.json
 .vscode-test
 extensions/pearai-submodule
 extensions/pearai-ref
+.prompts

--- a/src/vs/workbench/browser/parts/overlay/pearOverlayPart.ts
+++ b/src/vs/workbench/browser/parts/overlay/pearOverlayPart.ts
@@ -152,8 +152,11 @@ export class PearOverlayPart extends Part {
 
 		// if both content and webview are ready, end loading state and open
 		if (this.popupAreaOverlay && this.webviewView) {
-			this.webviewView?.webview.layoutWebviewOverElement(this.popupAreaOverlay);
-			this.open();
+			//this.webviewView?.webview.layoutWebviewOverElement(this.popupAreaOverlay);
+			// createContentArea is called within the workbench and layout when instantiating the overlay.
+			// If we don't close it here, it will open up by default when editor starts, or appear for half a second.
+			// If we remove this completely, it gets stuck in the loading stage, so we must close it.
+			this.close();
 		} else {
 			// hide stuff while we load
 			this.fullScreenOverlay!.style.display = "none";


### PR DESCRIPTION
* Console logs for debugging trace of overlay startup

* Revert "Console logs for debugging trace of overlay startup"

This reverts commit 70fa3bc021bcac48bbd4a387f0c1bc60ff9c4d27.

* Fix overlay appearing for half a second on startup

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
